### PR TITLE
Enable docformatter pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,8 @@ repos:
   hooks:
   - id: isort
     additional_dependencies: [toml]
+- repo: https://github.com/myint/docformatter
+  rev: v1.3.1
+  hooks:
+    - id: docformatter
+      args: [--in-place]

--- a/generic/event.py
+++ b/generic/event.py
@@ -1,4 +1,4 @@
-""" Event management system.
+"""Event management system.
 
 This module provides API for event management. There are two APIs provided:
 
@@ -24,7 +24,7 @@ HandlerSet = Set[Handler]
 
 
 class Manager:
-    """Event manager
+    """Event manager.
 
     Provides API for subscribing for and firing events. There's also global
     event manager instantiated at module level with functions
@@ -39,14 +39,14 @@ class Manager:
         self.registry = Registry(*axes)
 
     def subscribe(self, handler: Handler, event_type: Type[Event]) -> None:
-        """ Subscribe ``handler`` to specified ``event_type``"""
+        """Subscribe ``handler`` to specified ``event_type``"""
         handler_set = self.registry.get_registration(event_type)
         if handler_set is None:
             handler_set = self._register_handler_set(event_type)
         handler_set.add(handler)
 
     def unsubscribe(self, handler: Handler, event_type: Type[Event]) -> None:
-        """ Unsubscribe ``handler`` from ``event_type``"""
+        """Unsubscribe ``handler`` from ``event_type``"""
         handler_set = self.registry.get_registration(event_type)
         if handler_set and handler in handler_set:
             handler_set.remove(handler)
@@ -69,7 +69,7 @@ class Manager:
         return handler_set
 
     def subscriber(self, event_type: Type[Event]) -> Callable[[Handler], Handler]:
-        """Decorator for subscribing handlers
+        """Decorator for subscribing handlers.
 
         Works like this:
 
@@ -82,7 +82,6 @@ class Manager:
             ...     return
 
             >>> mymanager.handle(MyEvent())
-
         """
 
         def registrator(func: Handler) -> Handler:

--- a/generic/multidispatch.py
+++ b/generic/multidispatch.py
@@ -1,4 +1,4 @@
-""" Multidispatch for functions and methods.
+"""Multidispatch for functions and methods.
 
 This code is a Python 3, slimmed down version of the
 generic package by Andrey Popp.
@@ -24,11 +24,11 @@ KeyType = Union[type, None]
 
 
 def multidispatch(*argtypes: KeyType) -> Callable[[T], FunctionDispatcher[T]]:
-    """Declare function as multidispatch
+    """Declare function as multidispatch.
 
-    This decorator takes ``argtypes`` argument types and replace decorated
-    function with :class:`.FunctionDispatcher` object, which is responsible for
-    multiple dispatch feature.
+    This decorator takes ``argtypes`` argument types and replace
+    decorated function with :class:`.FunctionDispatcher` object, which
+    is responsible for multiple dispatch feature.
     """
 
     def _replace_with_dispatcher(func: T) -> FunctionDispatcher[T]:
@@ -52,7 +52,7 @@ def multidispatch(*argtypes: KeyType) -> Callable[[T], FunctionDispatcher[T]]:
 
 
 class FunctionDispatcher(Generic[T]):
-    """Multidispatcher for functions
+    """Multidispatcher for functions.
 
     This object dispatch calls to function by its argument types. Usually it is
     produced by :func:`.multidispatch` decorator.
@@ -100,28 +100,29 @@ class FunctionDispatcher(Generic[T]):
             )
 
     def register_rule(self, rule: T, *argtypes: KeyType) -> None:
-        """ Register new ``rule`` for ``argtypes``."""
+        """Register new ``rule`` for ``argtypes``."""
         self.check_rule(rule, *argtypes)
         self.registry.register(rule, *argtypes)
 
     def register(self, *argtypes: KeyType) -> Callable[[T], T]:
-        """Decorator for registering new case for multidispatch
+        """Decorator for registering new case for multidispatch.
 
-        New case will be registered for types identified by ``argtypes``. The
-        length of ``argtypes`` should be equal to the length of ``argtypes``
-        argument were passed corresponding :func:`.multidispatch` call, which
-        also indicated the number of arguments multidispatch dispatches on.
+        New case will be registered for types identified by
+        ``argtypes``. The length of ``argtypes`` should be equal to the
+        length of ``argtypes`` argument were passed corresponding
+        :func:`.multidispatch` call, which also indicated the number of
+        arguments multidispatch dispatches on.
         """
 
         def register_rule(func: T) -> T:
-            """ Register rule wrapper function."""
+            """Register rule wrapper function."""
             self.register_rule(func, *argtypes)
             return func
 
         return register_rule
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        """ Dispatch call to appropriate rule."""
+        """Dispatch call to appropriate rule."""
         trimmed_args = args[: self.params_arity]
         rule = self.registry.lookup(*trimmed_args)
         if not rule:
@@ -131,7 +132,7 @@ class FunctionDispatcher(Generic[T]):
 
 
 def _arity(argspec: inspect.FullArgSpec) -> int:
-    """ Determinal positional arity of argspec."""
+    """Determinal positional arity of argspec."""
     args = argspec.args if argspec.args else []
     defaults = argspec.defaults if argspec.defaults else []
     return len(args) - len(defaults)

--- a/generic/multimethod.py
+++ b/generic/multimethod.py
@@ -1,7 +1,5 @@
-"""
-Multi-method builds on the functionality provided by `multidispatch`
-to provide generic methods.
-"""
+"""Multi-method builds on the functionality provided by `multidispatch` to
+provide generic methods."""
 
 from __future__ import annotations
 
@@ -20,7 +18,7 @@ T = TypeVar("T", bound=Union[Callable[..., Any], type])
 
 
 def multimethod(*argtypes: KeyType) -> Callable[[T], MethodDispatcher[T]]:
-    """Declare method as multimethod
+    """Declare method as multimethod.
 
     This decorator works exactly the same as :func:`.multidispatch` decorator
     but replaces decorated method with :class:`.MethodDispatcher` object
@@ -47,7 +45,7 @@ def multimethod(*argtypes: KeyType) -> Callable[[T], MethodDispatcher[T]]:
 
 
 def has_multimethods(cls: Type[C]) -> Type[C]:
-    """Declare class as one that have multimethods
+    """Declare class as one that have multimethods.
 
     Should only be used for decorating classes which have methods decorated with
     :func:`.multimethod` decorator.
@@ -59,7 +57,7 @@ def has_multimethods(cls: Type[C]) -> Type[C]:
 
 
 class MethodDispatcher(FunctionDispatcher[T]):
-    """Multiple dispatch for methods
+    """Multiple dispatch for methods.
 
     This object dispatch call to method by its class and arguments types.
     Usually it is produced by :func:`.multimethod` decorator.
@@ -80,7 +78,7 @@ class MethodDispatcher(FunctionDispatcher[T]):
         self.local.unbound_rules.append((argtypes, func))
 
     def proceed_unbound_rules(self, cls) -> None:
-        """ Process all unbound rule by binding them to ``cls`` type."""
+        """Process all unbound rule by binding them to ``cls`` type."""
         for argtypes, func in self.local.unbound_rules:
             argtypes = (cls,) + argtypes
             print("register rule", argtypes)
@@ -93,7 +91,7 @@ class MethodDispatcher(FunctionDispatcher[T]):
         return types.MethodType(self, obj)
 
     def register(self, *argtypes: KeyType) -> Callable[[T], T]:
-        """ Register new case for multimethod for ``argtypes``"""
+        """Register new case for multimethod for ``argtypes``"""
 
         def make_declaration(meth):
             self.register_unbound_rule(meth, *argtypes)
@@ -103,7 +101,7 @@ class MethodDispatcher(FunctionDispatcher[T]):
 
     @property
     def otherwise(self) -> Callable[[T], T]:
-        """ Decorator which registers "catch-all" case for multimethod"""
+        """Decorator which registers "catch-all" case for multimethod."""
 
         def make_declaration(meth):
             self.register_unbound_rule(meth, *([object] * (self.params_arity - 1)))

--- a/generic/registry.py
+++ b/generic/registry.py
@@ -1,4 +1,4 @@
-""" Registry.
+"""Registry.
 
 This implementation was borrowed from happy[1] project by Chris Rossi.
 
@@ -31,7 +31,7 @@ Axis = Union["SimpleAxis", "TypeAxis"]
 
 
 class Registry(Generic[T]):
-    """ Registry implementation."""
+    """Registry implementation."""
 
     def __init__(self, *axes: Tuple[str, Axis]):
         self._tree: _TreeNode[T] = _TreeNode()
@@ -139,8 +139,8 @@ class SimpleAxis:
     something by name, where you're registering an object with the string that
     is the name and then using the name to look it up again later.
 
-    Subclasses can override the ``get_keys`` method for implementing arbitrary
-    axes.
+    Subclasses can override the ``get_keys`` method for implementing
+    arbitrary axes.
     """
 
     def matches(
@@ -152,9 +152,8 @@ class SimpleAxis:
 
 
 class TypeAxis:
-    """An axis which matches the class and super classes of an object in
-    method resolution order.
-    """
+    """An axis which matches the class and super classes of an object in method
+    resolution order."""
 
     def matches(
         self, obj: object, keys: KeysView[Optional[type]]

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,4 +1,4 @@
-""" Tests for :module:`generic.event`."""
+"""Tests for :module:`generic.event`."""
 
 from __future__ import annotations
 

--- a/tests/test_multidispatch.py
+++ b/tests/test_multidispatch.py
@@ -1,4 +1,4 @@
-""" Tests for :module:`generic.multidispatch`."""
+"""Tests for :module:`generic.multidispatch`."""
 
 from inspect import FullArgSpec
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,4 +1,4 @@
-""" Tests for :module:`generic.registry`."""
+"""Tests for :module:`generic.registry`."""
 
 from typing import Union
 


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

Enable the docformatter pre-commit hook to standardize the formatting of the docstrings.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and am following the [Contributor guide](https://github.com/gaphor/generic/blob/master/CONTRIBUTING.md)
- [X] I have read and understand the [Code of Conduct](https://github.com/gaphor/generic/blob/master/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
