### PR TITLE
Event manager exceptions

### DIFF
--- a/generic/event.py
+++ b/generic/event.py
@@ -1,15 +1,6 @@
 """Event management system.
 
-This module provides API for event management. There are two APIs provided:
-
-* Global event management API: subscribe, unsubscribe, handle.
-* Local event management API: Manager
-
-If you run only one instance of your application per Python
-interpreter you can stick with global API, but if you want to have
-more than one application instances running inside one interpreter and
-to have different configurations for them -- you should use local API
-and have one instance of Manager object per application instance.
+This module provides API for event management.
 """
 
 from typing import Callable, Set, Type
@@ -26,10 +17,7 @@ HandlerSet = Set[Handler]
 class Manager:
     """Event manager.
 
-    Provides API for subscribing for and firing events. There's also global
-    event manager instantiated at module level with functions
-    :func:`.subscribe`, :func:`.handle` and decorator :func:`.subscriber` aliased
-    to corresponding methods of class.
+    Provides API for subscribing for and firing events.
     """
 
     registry: Registry[HandlerSet]

--- a/poetry.lock
+++ b/poetry.lock
@@ -97,6 +97,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "exceptiongroup"
+version = "1.0.0rc5"
+description = "Backport of PEP 654 (exception groups)"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "filelock"
 version = "3.6.0"
 description = "A platform independent file lock."
@@ -371,7 +382,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "79d464bcfe246e843005ff88d4ddc655a5196d74978599b33ccb890a1d3952fa"
+content-hash = "eba382a768aa480dee8fdcc297e96e6bd5db4c2faf7b9d368b70a58036dcc083"
 
 [metadata.files]
 atomicwrites = [
@@ -468,6 +479,10 @@ coverage = [
 distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
     {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
+]
+exceptiongroup = [
+    {file = "exceptiongroup-1.0.0rc5-py3-none-any.whl", hash = "sha256:295a9d7847f9ad08267f47c701a676ec70a64200a360dd49eb513f72209b09f4"},
+    {file = "exceptiongroup-1.0.0rc5.tar.gz", hash = "sha256:665422550b9653acd46e9cd35d933f28c5158ca4c058c53619cfa112915cd69e"},
 ]
 filelock = [
     {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
+exceptiongroup = "^1.0.0-rc.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1"

--- a/tests/test_event_exception.py
+++ b/tests/test_event_exception.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+from exceptiongroup import ExceptionGroup
+
+from generic.event import Event, Manager
+
+
+@pytest.fixture
+def events():
+    return Manager()
+
+
+def make_handler(effect: object) -> Callable[[Event], None]:
+    def handler(e):
+        e.effects.append(effect)
+        raise ValueError(effect)
+
+    return handler
+
+
+def test_handle_all_subscribers(events):
+    events.subscribe(make_handler("handler1"), MyEvent)
+    events.subscribe(make_handler("handler2"), MyEvent)
+    e = MyEvent()
+    with pytest.raises(ExceptionGroup):
+        events.handle(e)
+
+    assert len(e.effects) == 2
+    assert "handler1" in e.effects
+    assert "handler2" in e.effects
+
+
+def test_collect_all_exceptions(events):
+    events.subscribe(make_handler("handler1"), MyEvent)
+    events.subscribe(make_handler("handler2"), MyEvent)
+    e = MyEvent()
+    with pytest.raises(ExceptionGroup) as excinfo:
+        events.handle(e)
+
+    exc = excinfo.value
+    nested_exc = [str(e) for e in exc.exceptions]
+    assert len(exc.exceptions) == 2
+    assert "handler1" in nested_exc
+    assert "handler2" in nested_exc
+
+
+class MyEvent:
+    def __init__(self) -> None:
+        self.effects: list[object] = []


### PR DESCRIPTION
<!-- Please add an overview of the PR here -->

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

If an exception is raised from an event handler, the remaining handlers are not executed.
This can result in inconsistent behavior.

### What is the new behavior?

It accumulates the exceptions and raises an ExceptionGroup
exception if there were any failures.

Rationale:

Event handlers should not be dependent on the order in which they
are executed.

If a handler fails the remaining handlers are not executed.
This can result in non-deterministic behavior.

This commit fixes that my allowing all handlers to be executed.

To make this work we use the (back-ported) ExceptionGroup from
Python 3.11.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
