### PR TITLE
fix(event): don't attempt to import `exceptiongroup` if running python 3.11+

### DIFF
--- a/generic/event.py
+++ b/generic/event.py
@@ -3,9 +3,11 @@
 This module provides API for event management.
 """
 
+from sys import version_info
 from typing import Callable, Set, Type
 
-from exceptiongroup import ExceptionGroup
+if version_info < (3, 11):
+    from exceptiongroup import ExceptionGroup
 
 from generic.registry import Registry, TypeAxis
 

--- a/tests/test_event_exception.py
+++ b/tests/test_event_exception.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from sys import version_info
 from typing import Callable
 
 import pytest
-from exceptiongroup import ExceptionGroup
+if version_info < (3, 11):
+    from exceptiongroup import ExceptionGroup
 
 from generic.event import Event, Manager
 


### PR DESCRIPTION
don't attempt to import `exceptiongroup` if running python 3.11+


### PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I have read, and I am following the [Contributor guide](https://github.com/gaphor/generic/blob/main/CONTRIBUTING.md)
- [x] I have read and understand the [Code of Conduct](https://github.com/gaphor/generic/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
