### PR TITLE
Fix build with recent sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -243,4 +243,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"http://docs.python.org/": None}
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}


### PR DESCRIPTION
This fixes the following error when build the documentation with Sphinx v8.1.3:
```
ERROR: Invalid value `None` in intersphinx_mapping['http://docs.python.org/']. Expected a two-element tuple or list.

Configuration error:
Invalid `intersphinx_mapping` configuration (1 error).
```